### PR TITLE
vs985: add 24B back as a valid baseband

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,1 @@
-require version-baseband=35B:MPSS.DI.2.0.1.C1.13.4-00005
+require version-baseband=24B:MPSS.DI.2.0.1.C1.13-00073|35B:MPSS.DI.2.0.1.C1.13.4-00005


### PR DESCRIPTION
- Anything newer seems to wreak havoc due to mismatched aboot
  (which is old as fuck because we need the vulnerable one still)
- This baseband/bootstack seems to be the best as far as
  booting consistently

Change-Id: I291e0bdaa3ede04ccc2631f5852f7a82031d0b75
